### PR TITLE
Call `View.generateViewId` directly (`ViewCompat.generateViewId` is deprecated)

### DIFF
--- a/app/src/main/java/rs/ruffle/PlayerActivity.kt
+++ b/app/src/main/java/rs/ruffle/PlayerActivity.kt
@@ -157,7 +157,7 @@ class PlayerActivity : GameActivity() {
         @SuppressLint("InflateParams")
         val layout = inflater.inflate(R.layout.keyboard, null) as ConstraintLayout
 
-        contentViewId = ViewCompat.generateViewId()
+        contentViewId = View.generateViewId()
         layout.id = contentViewId
         setContentView(layout)
         mSurfaceView = InputEnabledSurfaceView(this)


### PR DESCRIPTION
https://github.com/ruffle-rs/ruffle-android/actions/runs/15757546868/job/44416418042#step:9:68
https://developer.android.com/reference/kotlin/androidx/core/view/ViewCompat#generateViewId()