### PR TITLE
Upgrade Android Gradle Plugin (agp) to 8.13.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.11.1"
+agp = "8.13.0"
 kotlin = "2.2.21"
 coreKtx = "1.16.0"
 junit = "4.13.2"


### PR DESCRIPTION
Basically (but not quite) reverts https://github.com/ruffle-rs/ruffle-android/pull/526.
See: https://github.com/ruffle-rs/ruffle-android/issues/522#issuecomment-3552115987