### PR TITLE
Use a more actively maintained cargo-ndk gradle integration plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,6 @@ androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-cargoNdkAndroid = { id = "com.github.willir.rust.cargo-ndk-android", version = "0.3.4" }
+cargoNdkAndroid = { id = "com.gemwallet.cargo-ndk", version = "0.5.3" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 


### PR DESCRIPTION
This is a fork of the one used currently: https://github.com/gemwalletcom/cargo-ndk-android-gradle