### PR TITLE
chore: Add rust-toolchain to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "rust-toolchain"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
https://github.blog/changelog/2025-08-19-dependabot-now-supports-rust-toolchain-updates/