### PR TITLE
Make Ruffle only register for Flash related files

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,27 +42,73 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".MainActivity" />
 
+            <!-- Handle only flash related files ( .swf, .spl) -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
-
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
-                <category android:name="android.intent.category.OPENABLE" />
-
+                <category android:name="android.intent.category.OPENABLE"/>
                 <data android:scheme="file"/>
                 <data android:scheme="content"/>
-                <data android:scheme="http" />
-                <data android:scheme="https" />
+                <data android:scheme="http"/>
+                <data android:scheme="https"/>
+                <data android:mimeType="application/x-shockwave-flash"/>
+                <data android:mimeType="application/futuresplash"/>
+            </intent-filter>
 
-                <!--
-                Ideally "application/x-shockwave-flash" would be
-                used here, but Android doesn't recognize many
-                downloaded .swf files as such for some reason... :/
-                -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <category android:name="android.intent.category.OPENABLE"/>
+                <data android:scheme="file"/>
+                <data android:scheme="content"/>
+                <data android:scheme="http"/>
+                <data android:scheme="https"/>
                 <data android:mimeType="*/*"/>
+                <data android:host="*"/>
+                <data android:pathPattern=".*\\.swf"/> <!-- match .swf / .SWF with multiple dots for backwards compatibility -->
+                <data android:pathPattern=".*\\.SWF"/>
+                <data android:pathPattern=".*\\..*\\.swf"/>
+                <data android:pathPattern=".*\\..*\\.SWF"/>
+                <data android:pathPattern=".*\\..*\\..*\\.swf"/>
+                <data android:pathPattern=".*\\..*\\..*\\.SWF"/>
+                <data android:pathPattern=".*\\.spl"/>
+                <data android:pathPattern=".*\\.SPL"/>
+                <data android:pathPattern=".*\\..*\\.spl"/>
+                <data android:pathPattern=".*\\..*\\.SPL"/>
+                <data android:pathPattern=".*\\..*\\..*\\.spl"/>
+                <data android:pathPattern=".*\\..*\\..*\\.SPL"/>
+                <data android:pathSuffix="swf"/> <!-- support Android 12+ pathSuffix -->
+                <data android:pathSuffix="SWF"/>
+                <data android:pathSuffix="spl"/>
+                <data android:pathSuffix="SPL"/>
+            </intent-filter>
 
-                <data android:host="*" />
-                <data android:pathSuffix="swf" />
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="file"/>
+                <data android:scheme="http"/>
+                <data android:scheme="https"/>
+                <data android:host="*"/>
+                <data android:pathPattern=".*\\.swf"/> <!-- match .swf / .SWF with multiple dots for backwards compatibility -->
+                <data android:pathPattern=".*\\.SWF"/>
+                <data android:pathPattern=".*\\..*\\.swf"/>
+                <data android:pathPattern=".*\\..*\\.SWF"/>
+                <data android:pathPattern=".*\\..*\\..*\\.swf"/>
+                <data android:pathPattern=".*\\..*\\..*\\.SWF"/>
+                <data android:pathPattern=".*\\.spl"/>
+                <data android:pathPattern=".*\\.SPL"/>
+                <data android:pathPattern=".*\\..*\\.spl"/>
+                <data android:pathPattern=".*\\..*\\.SPL"/>
+                <data android:pathPattern=".*\\..*\\..*\\.spl"/>
+                <data android:pathPattern=".*\\..*\\..*\\.SPL"/>
+                <data android:pathSuffix="swf"/> <!-- support Android 12+ pathSuffix -->
+                <data android:pathSuffix="SWF"/>
+                <data android:pathSuffix="spl"/>
+                <data android:pathSuffix="SPL"/>
             </intent-filter>
         </activity>
     </application>


### PR DESCRIPTION
This commit restricts ruffle to only register as an intent handler for flash related files (MIME types application/x-shockwave-flash and .swf/.spl extensions) with backward compatibility for older Android versions. Refer to the below screenshots for exactly what was fixed.

**BEFORE** : Ruffle offer to open even an mp3 file
<img width="540" height="893" alt="Screenshot_20260617-153947~2" src="https://github.com/user-attachments/assets/c32457ed-ff1b-4570-a776-fd1f0b948165" />

**AFTER** : Ruffle explicitly only handles shockwave files
<img width="540" height="893" alt="Screenshot_20260617-154047~2" src="https://github.com/user-attachments/assets/e265169c-da45-465b-8fa4-512853867429" />